### PR TITLE
refactor: Change behaviour of history command to default to show warnings

### DIFF
--- a/Zhongli.Bot/Modules/UserModule.cs
+++ b/Zhongli.Bot/Modules/UserModule.cs
@@ -35,7 +35,7 @@ namespace Zhongli.Bot.Modules
         public async Task InfractionsAsync(
             [Summary("The user to show the infractions of.")]
             IUser? user = null,
-            [Summary("Leave empty to show everything.")]
+            [Summary("Leave empty to show warnings.")]
             InfractionType type = InfractionType.Warning)
         {
             user ??= Context.User;

--- a/Zhongli.Bot/Modules/UserModule.cs
+++ b/Zhongli.Bot/Modules/UserModule.cs
@@ -29,14 +29,14 @@ namespace Zhongli.Bot.Modules
         }
 
         [Command("history")]
-        [Alias("infraction", "infractions", "reprimand", "reprimands")]
+        [Alias("infraction", "infractions", "reprimand", "reprimands", "warnlist")]
         [Summary("View a specific history of a user's infractions.")]
         [RequireAuthorization(AuthorizationScope.Moderator)]
         public async Task InfractionsAsync(
             [Summary("The user to show the infractions of.")]
             IUser? user = null,
             [Summary("Leave empty to show everything.")]
-            InfractionType type = InfractionType.All)
+            InfractionType type = InfractionType.Warning)
         {
             user ??= Context.User;
             var userEntity = _db.Users.FirstOrDefault(u => u.Id == user.Id && u.GuildId == Context.Guild.Id);


### PR DESCRIPTION
This is following a request from mods:

"one change id ask is maybe making the default zhistory to show warnings only
since we aren't gonna need to see all of the actions in 90% of cases"