### PR TITLE
fix: Change order of kick on voice ban to avoid errors

### DIFF
--- a/Zhongli.Bot/Modules/VoiceChatModule.cs
+++ b/Zhongli.Bot/Modules/VoiceChatModule.cs
@@ -27,9 +27,9 @@ namespace Zhongli.Bot.Modules
 
             if (user.VoiceChannel?.Id == voiceChat.VoiceChannelId)
             {
-                await user.ModifyAsync(u => u.Channel = null);
                 await user.VoiceChannel.AddPermissionOverwriteAsync(user,
                     OverwritePermissions.DenyAll(user.VoiceChannel));
+                await user.ModifyAsync(u => u.Channel = null);
 
                 var textChannel = (IGuildChannel) Context.Channel;
                 await textChannel.AddPermissionOverwriteAsync(user,


### PR DESCRIPTION
Previously the ban would fail because channel was not defined due to the user getting kicked before Zhongli can grab their voice channel. This should fix any issue with voice ban command.