### PR TITLE
Incineratez/role permissions fix

### DIFF
--- a/Zhongli.Bot/Modules/RoleModule.cs
+++ b/Zhongli.Bot/Modules/RoleModule.cs
@@ -111,8 +111,10 @@ namespace Zhongli.Bot.Modules
         [Summary("Creates a role.")]
         public async Task CreateRoleAsync(string name, RoleCreationOptions? options = null)
         {
+            GuildPermissions gperms = CreateGuildPermissions(options?.Perms ?? "");
+
             var role = await Context.Guild.CreateRoleAsync(name,
-                options?.Permissions, options?.Color,
+                gperms, options?.Color,
                 options?.IsHoisted ?? false,
                 options?.IsMentionable ?? false);
 
@@ -207,8 +209,10 @@ namespace Zhongli.Bot.Modules
         [Summary("Creates a temporary role that gets deleted after a specified time.")]
         public async Task TemporaryRoleCreateAsync(string name, TimeSpan length, RoleCreationOptions? options = null)
         {
+            GuildPermissions gperms = CreateGuildPermissions(options?.Perms ?? "");
+
             var role = await Context.Guild.CreateRoleAsync(name,
-                options?.Permissions, options?.Color,
+                gperms, options?.Color,
                 options?.IsHoisted ?? false,
                 options?.IsMentionable ?? false);
 
@@ -240,6 +244,25 @@ namespace Zhongli.Bot.Modules
                     await ViewRolesInfoAsync(roles);
                     break;
             }
+        }
+        
+        private GuildPermissions CreateGuildPermissions(string permissions) {
+            GuildPermissions gperms = new GuildPermissions(createInstantInvite: true, addReactions: true, stream: true, sendMessages: true, sendTTSMessages: true, embedLinks: true, attachFiles: true, readMessageHistory: true, mentionEveryone: true, useExternalEmojis: true, connect:true, speak: true, changeNickname: true);
+
+            if(!Equals(permissions, "")) {
+                string[] perms = permissions.Split(" ");
+
+                var dict = new Dictionary<String, Boolean>();
+
+                foreach(string p in perms)
+                {
+                    dict[p.ToLower()] = true;
+                }
+
+                gperms = gperms.Modify(/*createInstantInvite: dict.GetValueOrDefault("createinstantinvite", false),*/ kickMembers: dict.GetValueOrDefault("kickmembers", false), banMembers: dict.GetValueOrDefault("banmembers", false), administrator: dict.GetValueOrDefault("administrator", false), manageChannels: dict.GetValueOrDefault("managechannels", false), manageGuild: dict.GetValueOrDefault("manageguild", false), /*addReactions: dict.GetValueOrDefault("addreactions", false),*/ viewAuditLog: dict.GetValueOrDefault("viewauditlog", false), viewGuildInsights: dict.GetValueOrDefault("viewguildinsights", false), viewChannel: dict.GetValueOrDefault("viewchannel", false), /*sendMessages: dict.GetValueOrDefault("sendmessages", false),*/ /*sendTTSMessages: dict.GetValueOrDefault("sendttsmessages", false),*/ manageMessages: dict.GetValueOrDefault("managemessages", false), /*embedLinks: dict.GetValueOrDefault("embedlinks", false),*/ /*attachFiles: dict.GetValueOrDefault("attachfiles", false),*/ /*readMessageHistory: dict.GetValueOrDefault("readmessagehistory", false),*/ /*mentionEveryone: dict.GetValueOrDefault("mentioneveryone", false),*/ /*useExternalEmojis: dict.GetValueOrDefault("useexternalemojis", false),*/ /*connect: dict.GetValueOrDefault("connect", false),*/ /*speak: dict.GetValueOrDefault("speak", false),*/ muteMembers: dict.GetValueOrDefault("mutemembers", false), deafenMembers: dict.GetValueOrDefault("deafenmembers", false), moveMembers: dict.GetValueOrDefault("movemembers", false), useVoiceActivation: dict.GetValueOrDefault("usevoiceactivation", false), prioritySpeaker: dict.GetValueOrDefault("priorityspeaker", false), /*stream: dict.GetValueOrDefault("stream", false),*/ /*changeNickname: dict.GetValueOrDefault("changenickname", false),*/ manageNicknames: dict.GetValueOrDefault("managenicknames", false), manageRoles: dict.GetValueOrDefault("manageroles", false), manageWebhooks: dict.GetValueOrDefault("managewebhooks", false), manageEmojis: dict.GetValueOrDefault("manageemojis", false));
+            }
+
+            return gperms;
         }
 
         private static EmbedFieldBuilder CreateRoleEmbedField(SocketRole role)
@@ -306,7 +329,9 @@ namespace Zhongli.Bot.Modules
             public Color? Color { get; set; }
 
             [HelpSummary("List of permissions")]
-            public GuildPermissions? Permissions { get; set; }
+            public string? Perms { get; set ; }
+
+            public GuildPermissions? Permissions;
         }
     }
 }

--- a/Zhongli.Bot/Modules/RoleModule.cs
+++ b/Zhongli.Bot/Modules/RoleModule.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
 using Discord;
 using Discord.Addons.Interactive;
 using Discord.Addons.Interactive.Paginator;
@@ -5,16 +11,9 @@ using Discord.Commands;
 using Discord.Net;
 using Discord.WebSocket;
 using Humanizer;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 using Zhongli.Services.CommandHelp;
 using Zhongli.Services.Expirable;
 using Zhongli.Services.Utilities;
-using Zhongli.Services.CommandHelp;
 
 namespace Zhongli.Bot.Modules
 {
@@ -30,7 +29,7 @@ namespace Zhongli.Bot.Modules
         public RoleModule(TemporaryRoleMemberService member, TemporaryRoleService role)
         {
             _member = member;
-            _role = role;
+            _role   = role;
         }
 
         [Command("add")]
@@ -43,8 +42,6 @@ namespace Zhongli.Bot.Modules
         [Summary("Adds specified roles to a user.")]
         public async Task AddRolesAsync(IGuildUser user, params IRole[] roles)
         {
-
-
             await user.AddRolesAsync(roles);
 
             var embed = new EmbedBuilder()
@@ -88,7 +85,8 @@ namespace Zhongli.Bot.Modules
         public async Task AddTemporaryRoleMemberAsync(IGuildUser user, IRole role, TimeSpan length)
         {
             await _member.AddTemporaryRoleMemberAsync(user, role, length);
-            await ReplyAsync($"Added {Format.Bold(role.Name)} to {Format.Bold(user.GetFullUsername())} that ends {length.ToUniversalTimestamp()}.");
+            await ReplyAsync(
+                $"Added {Format.Bold(role.Name)} to {Format.Bold(user.GetFullUsername())} that ends {length.ToUniversalTimestamp()}.");
         }
 
         [Command("color")]
@@ -101,7 +99,7 @@ namespace Zhongli.Bot.Modules
             }
 
             var embed = new EmbedBuilder()
-                .WithDescription($"Color changed succesfully")
+                .WithDescription("Color changed successfully")
                 .WithColor(color);
 
             await ReplyAsync(embed: embed.Build());
@@ -111,18 +109,20 @@ namespace Zhongli.Bot.Modules
         [Summary("Creates a role.")]
         public async Task CreateRoleAsync(string name, RoleCreationOptions? options = null)
         {
+            var guildPermissions = options?.Permissions?.ToGuildPermissions();
             var role = await Context.Guild.CreateRoleAsync(name,
-                options?.Permissions, options?.Color,
+                guildPermissions, options?.Color,
                 options?.IsHoisted ?? false,
                 options?.IsMentionable ?? false);
 
+            var permissions = role.Permissions.ToList().Select(p => p.Humanize());
             var embed = new EmbedBuilder()
-                .WithDescription($"Created the following role: {Format.Bold(role.Name)} with the provided options.")
                 .WithColor(role.Color)
-                .AddField("Hoisted: ", role.IsHoisted, true)
-                .AddField("Mentionable: ", role.IsMentionable, true)
-                .AddField("Color: ", role.Color, true)
-                .AddField("Permissions: ", role.Permissions.ToList().Humanize(p => p.Humanize()), true);
+                .WithDescription($"Created the following role: {Format.Bold(role.Name)} with the provided options.")
+                .AddField("Hoisted", role.IsHoisted, true)
+                .AddField("Mentionable", role.IsMentionable, true)
+                .AddField("Color", role.Color, true)
+                .AddItemsIntoFields("Permissions", permissions, ", ");
 
             await ReplyAsync(embed: embed.Build());
         }
@@ -207,8 +207,9 @@ namespace Zhongli.Bot.Modules
         [Summary("Creates a temporary role that gets deleted after a specified time.")]
         public async Task TemporaryRoleCreateAsync(string name, TimeSpan length, RoleCreationOptions? options = null)
         {
+            var permissions = options?.Permissions?.ToGuildPermissions();
             var role = await Context.Guild.CreateRoleAsync(name,
-                options?.Permissions, options?.Color,
+                permissions, options?.Color,
                 options?.IsHoisted ?? false,
                 options?.IsMentionable ?? false);
 
@@ -282,7 +283,7 @@ namespace Zhongli.Bot.Modules
 
             var message = new PaginatedMessage
             {
-                Pages = fields,
+                Pages  = fields,
                 Author = new EmbedAuthorBuilder().WithGuildAsAuthor(Context.Guild),
                 Options = new PaginatedAppearanceOptions
                 {
@@ -305,8 +306,7 @@ namespace Zhongli.Bot.Modules
             [HelpSummary("Choose the color of the role")]
             public Color? Color { get; set; }
 
-            [HelpSummary("List of permissions")]
-            public GuildPermissions? Permissions { get; set; }
+            [HelpSummary("List of permissions")] public IEnumerable<GuildPermission>? Permissions { get; set; }
         }
     }
 }

--- a/Zhongli.Bot/Modules/RoleModule.cs
+++ b/Zhongli.Bot/Modules/RoleModule.cs
@@ -198,6 +198,7 @@ namespace Zhongli.Bot.Modules
                 .AddField("Role", role.Mention, true)
                 .AddField("Mentionable", role.IsMentionable, true)
                 .AddField("Hoisted", role.IsHoisted, true)
+                .AddField("Permissions: ", role.Permissions.ToList().Humanize(p => p.Humanize()), true)
                 .WithCurrentTimestamp()
                 .WithUserAsAuthor(Context.Message.Author, AuthorOptions.Requested | AuthorOptions.UseFooter);
 
@@ -207,16 +208,18 @@ namespace Zhongli.Bot.Modules
         [Command("temporary create")]
         [Alias("tempcreate")]
         [Summary("Creates a temporary role that gets deleted after a specified time.")]
-        public async Task TemporaryRoleCreateAsync(string name, TimeSpan length, RoleCreationOptions? options = null)
+        public async Task TemporaryRoleCreateAsync(string name, long length, RoleCreationOptions? options = null)
         {
             GuildPermissions gperms = CreateGuildPermissions(options?.Perms ?? "");
+
+            TimeSpan ts = TimeSpan.FromTicks(length);
 
             var role = await Context.Guild.CreateRoleAsync(name,
                 gperms, options?.Color,
                 options?.IsHoisted ?? false,
                 options?.IsMentionable ?? false);
 
-            await TemporaryRoleConvertAsync(role, length);
+            await TemporaryRoleConvertAsync(role, ts);
         }
 
         [Command]
@@ -246,10 +249,12 @@ namespace Zhongli.Bot.Modules
             }
         }
         
-        private GuildPermissions CreateGuildPermissions(string permissions) {
+        private GuildPermissions CreateGuildPermissions(string permissions) 
+        {
             GuildPermissions gperms = new GuildPermissions(createInstantInvite: true, addReactions: true, stream: true, sendMessages: true, sendTTSMessages: true, embedLinks: true, attachFiles: true, readMessageHistory: true, mentionEveryone: true, useExternalEmojis: true, connect:true, speak: true, changeNickname: true);
 
-            if(!Equals(permissions, "")) {
+            if(!Equals(permissions, "")) 
+            {
                 string[] perms = permissions.Split(" ");
 
                 var dict = new Dictionary<String, Boolean>();

--- a/Zhongli.Bot/Modules/RoleModule.cs
+++ b/Zhongli.Bot/Modules/RoleModule.cs
@@ -198,7 +198,6 @@ namespace Zhongli.Bot.Modules
                 .AddField("Role", role.Mention, true)
                 .AddField("Mentionable", role.IsMentionable, true)
                 .AddField("Hoisted", role.IsHoisted, true)
-                .AddField("Permissions: ", role.Permissions.ToList().Humanize(p => p.Humanize()), true)
                 .WithCurrentTimestamp()
                 .WithUserAsAuthor(Context.Message.Author, AuthorOptions.Requested | AuthorOptions.UseFooter);
 
@@ -208,18 +207,16 @@ namespace Zhongli.Bot.Modules
         [Command("temporary create")]
         [Alias("tempcreate")]
         [Summary("Creates a temporary role that gets deleted after a specified time.")]
-        public async Task TemporaryRoleCreateAsync(string name, long length, RoleCreationOptions? options = null)
+        public async Task TemporaryRoleCreateAsync(string name, TimeSpan length, RoleCreationOptions? options = null)
         {
             GuildPermissions gperms = CreateGuildPermissions(options?.Perms ?? "");
-
-            TimeSpan ts = TimeSpan.FromTicks(length);
 
             var role = await Context.Guild.CreateRoleAsync(name,
                 gperms, options?.Color,
                 options?.IsHoisted ?? false,
                 options?.IsMentionable ?? false);
 
-            await TemporaryRoleConvertAsync(role, ts);
+            await TemporaryRoleConvertAsync(role, length);
         }
 
         [Command]
@@ -249,12 +246,10 @@ namespace Zhongli.Bot.Modules
             }
         }
         
-        private GuildPermissions CreateGuildPermissions(string permissions) 
-        {
+        private GuildPermissions CreateGuildPermissions(string permissions) {
             GuildPermissions gperms = new GuildPermissions(createInstantInvite: true, addReactions: true, stream: true, sendMessages: true, sendTTSMessages: true, embedLinks: true, attachFiles: true, readMessageHistory: true, mentionEveryone: true, useExternalEmojis: true, connect:true, speak: true, changeNickname: true);
 
-            if(!Equals(permissions, "")) 
-            {
+            if(!Equals(permissions, "")) {
                 string[] perms = permissions.Split(" ");
 
                 var dict = new Dictionary<String, Boolean>();

--- a/Zhongli.Bot/Modules/RoleModule.cs
+++ b/Zhongli.Bot/Modules/RoleModule.cs
@@ -111,10 +111,8 @@ namespace Zhongli.Bot.Modules
         [Summary("Creates a role.")]
         public async Task CreateRoleAsync(string name, RoleCreationOptions? options = null)
         {
-            GuildPermissions gperms = CreateGuildPermissions(options?.Perms ?? "");
-
             var role = await Context.Guild.CreateRoleAsync(name,
-                gperms, options?.Color,
+                options?.Permissions, options?.Color,
                 options?.IsHoisted ?? false,
                 options?.IsMentionable ?? false);
 
@@ -209,10 +207,8 @@ namespace Zhongli.Bot.Modules
         [Summary("Creates a temporary role that gets deleted after a specified time.")]
         public async Task TemporaryRoleCreateAsync(string name, TimeSpan length, RoleCreationOptions? options = null)
         {
-            GuildPermissions gperms = CreateGuildPermissions(options?.Perms ?? "");
-
             var role = await Context.Guild.CreateRoleAsync(name,
-                gperms, options?.Color,
+                options?.Permissions, options?.Color,
                 options?.IsHoisted ?? false,
                 options?.IsMentionable ?? false);
 
@@ -244,25 +240,6 @@ namespace Zhongli.Bot.Modules
                     await ViewRolesInfoAsync(roles);
                     break;
             }
-        }
-        
-        private GuildPermissions CreateGuildPermissions(string permissions) {
-            GuildPermissions gperms = new GuildPermissions(createInstantInvite: true, addReactions: true, stream: true, sendMessages: true, sendTTSMessages: true, embedLinks: true, attachFiles: true, readMessageHistory: true, mentionEveryone: true, useExternalEmojis: true, connect:true, speak: true, changeNickname: true);
-
-            if(!Equals(permissions, "")) {
-                string[] perms = permissions.Split(" ");
-
-                var dict = new Dictionary<String, Boolean>();
-
-                foreach(string p in perms)
-                {
-                    dict[p.ToLower()] = true;
-                }
-
-                gperms = gperms.Modify(/*createInstantInvite: dict.GetValueOrDefault("createinstantinvite", false),*/ kickMembers: dict.GetValueOrDefault("kickmembers", false), banMembers: dict.GetValueOrDefault("banmembers", false), administrator: dict.GetValueOrDefault("administrator", false), manageChannels: dict.GetValueOrDefault("managechannels", false), manageGuild: dict.GetValueOrDefault("manageguild", false), /*addReactions: dict.GetValueOrDefault("addreactions", false),*/ viewAuditLog: dict.GetValueOrDefault("viewauditlog", false), viewGuildInsights: dict.GetValueOrDefault("viewguildinsights", false), viewChannel: dict.GetValueOrDefault("viewchannel", false), /*sendMessages: dict.GetValueOrDefault("sendmessages", false),*/ /*sendTTSMessages: dict.GetValueOrDefault("sendttsmessages", false),*/ manageMessages: dict.GetValueOrDefault("managemessages", false), /*embedLinks: dict.GetValueOrDefault("embedlinks", false),*/ /*attachFiles: dict.GetValueOrDefault("attachfiles", false),*/ /*readMessageHistory: dict.GetValueOrDefault("readmessagehistory", false),*/ /*mentionEveryone: dict.GetValueOrDefault("mentioneveryone", false),*/ /*useExternalEmojis: dict.GetValueOrDefault("useexternalemojis", false),*/ /*connect: dict.GetValueOrDefault("connect", false),*/ /*speak: dict.GetValueOrDefault("speak", false),*/ muteMembers: dict.GetValueOrDefault("mutemembers", false), deafenMembers: dict.GetValueOrDefault("deafenmembers", false), moveMembers: dict.GetValueOrDefault("movemembers", false), useVoiceActivation: dict.GetValueOrDefault("usevoiceactivation", false), prioritySpeaker: dict.GetValueOrDefault("priorityspeaker", false), /*stream: dict.GetValueOrDefault("stream", false),*/ /*changeNickname: dict.GetValueOrDefault("changenickname", false),*/ manageNicknames: dict.GetValueOrDefault("managenicknames", false), manageRoles: dict.GetValueOrDefault("manageroles", false), manageWebhooks: dict.GetValueOrDefault("managewebhooks", false), manageEmojis: dict.GetValueOrDefault("manageemojis", false));
-            }
-
-            return gperms;
         }
 
         private static EmbedFieldBuilder CreateRoleEmbedField(SocketRole role)
@@ -329,9 +306,7 @@ namespace Zhongli.Bot.Modules
             public Color? Color { get; set; }
 
             [HelpSummary("List of permissions")]
-            public string? Perms { get; set ; }
-
-            public GuildPermissions? Permissions;
+            public GuildPermissions? Permissions { get; set; }
         }
     }
 }

--- a/Zhongli.Services/Core/Listeners/CommandHandlingService.cs
+++ b/Zhongli.Services/Core/Listeners/CommandHandlingService.cs
@@ -78,6 +78,10 @@ namespace Zhongli.Services.Core.Listeners
                 new EnumFlagsTypeReader<RegexOptions>(
                     splitOptions: StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
 
+            _commands.AddTypeReader<GuildPermission>(
+                new EnumFlagsTypeReader<GuildPermission>(
+                    splitOptions: StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
+
             _commands.AddEnumerableTypeReader<LogType>(new EnumTryParseTypeReader<LogType>());
 
             await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services);

--- a/Zhongli.Services/Utilities/EnumExtensions.cs
+++ b/Zhongli.Services/Utilities/EnumExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using Discord;
 using Zhongli.Data.Models.Moderation;
 
 namespace Zhongli.Services.Utilities
@@ -7,6 +9,10 @@ namespace Zhongli.Services.Utilities
     {
         private static readonly GenericBitwise<ReprimandNoticeType> ReprimandNoticeTypeBitwise = new();
         private static readonly GenericBitwise<ReprimandOptions> ReprimandOptionsBitwise = new();
+        private static readonly GenericBitwise<GuildPermission> GuildPermissionBitwise = new();
+
+        public static GuildPermissions ToGuildPermissions(this IEnumerable<GuildPermission> permissions)
+            => new((uint) GuildPermissionBitwise.Or(permissions));
 
         public static ReprimandNoticeType SetValue(this ReprimandNoticeType options, ReprimandNoticeType flag,
             bool? state)


### PR DESCRIPTION
fixes issue with [p]!role create _name_ _[options]_ where an error is thrown when trying to add a Permissions option.

fixes issue with [p]!role temporary create _name_ _ticks_ _[options]_ where an error is thrown when trying to run the command.

major changes: 
- option "Permissions" renamed to "Perms".
- usage of Perms option modified to: `... "rolename" Perms: "permission1 permission2 permission3 ...."`