### PR TITLE
feat: Improve ban syntax in ModerationModule

### DIFF
--- a/Zhongli.Bot/Modules/Moderation/ModerationModule.cs
+++ b/Zhongli.Bot/Modules/Moderation/ModerationModule.cs
@@ -6,6 +6,7 @@ using Zhongli.Data;
 using Zhongli.Data.Models.Authorization;
 using Zhongli.Data.Models.Moderation;
 using Zhongli.Data.Models.Moderation.Infractions.Reprimands;
+using Zhongli.Services.CommandHelp;
 using Zhongli.Services.Core.Listeners;
 using Zhongli.Services.Core.Preconditions;
 using Zhongli.Services.Moderation;
@@ -49,6 +50,21 @@ namespace Zhongli.Bot.Modules.Moderation
             else
                 await ReplyReprimandAsync(result, details);
         }
+
+        [Command("ban")]
+        [HiddenFromHelp]
+        [Summary("Ban a user permanently from the current guild.")]
+        [RequireAuthorization(AuthorizationScope.Ban)]
+        public Task BanAsync(IUser user, [Remainder] string? reason = null)
+            => BanAsync(user, 0, null, reason);
+        
+        [Command("ban")]
+        [HiddenFromHelp]
+        [Summary("Ban a user permanently from the current guild, and delete messages.")]
+        [RequireAuthorization(AuthorizationScope.Ban)]
+        public Task BanAsync(IUser user, uint deleteDays = 1, [Remainder] string? reason = null)
+            => BanAsync(user, deleteDays, null, reason);
+        
 
         [Command("kick")]
         [Summary("Kick a user from the current guild.")]


### PR DESCRIPTION
This allows for a more human/fluid user experience by forcing all the arguments to be "optional". Not the prettiest solution, but sadly this is the only way to do it without having to use flags.