### PR TITLE
feat: Delete context message when using say

### DIFF
--- a/Zhongli.Bot/Modules/Moderation/ModerationModule.cs
+++ b/Zhongli.Bot/Modules/Moderation/ModerationModule.cs
@@ -126,6 +126,7 @@ namespace Zhongli.Bot.Modules.Moderation
         public async Task SayAsync(ITextChannel? channel, [Remainder] string message)
         {
             channel ??= (ITextChannel) Context.Channel;
+            await Context.Channel.DeleteMessageAsync(Context.Message.Id);
             await channel.SendMessageAsync(message, allowedMentions: AllowedMentions.None);
         }
 


### PR DESCRIPTION
This was suggested by the mods as "feedback" for the say command, and also for the sake of being able ot use say in a channel without the command being shown.